### PR TITLE
fix: update start script port from 1338 to 1339

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "build:prod": "cross-env NODE_ENV=production next build",
-    "start": "next dev -p 1338",
+    "start": "next dev -p 1339",
     "start:prod": "cross-env NODE_ENV=production next start",
     "server": "node server.js",
     "lint": "next lint",


### PR DESCRIPTION
This pull request includes a small change to the `apps/frontend/package.json` file. The change updates the port for the `start` script from `1338` to `1339` to avoid potential conflicts.