### PR TITLE
feat: add debug logging and adjust refetch intervals for employee ava…

### DIFF
--- a/apps/backend/app/services/discord_service.ts
+++ b/apps/backend/app/services/discord_service.ts
@@ -1444,33 +1444,25 @@ class DiscordService {
         return
       }
 
-      // Debug: Log tous les messages reçus dans le canal logs
-      logger.info(`📨 Message reçu dans canal logs: author=${message.author?.username}, content="${message.content}", embeds=${message.embeds.length}`)
-
       // Méthode alternative : analyser le contenu du message au lieu des embeds
       // Chercher des patterns dans le contenu du message qui indiquent un événement duty
       if (message.content && (message.content.includes('duty') || message.content.includes('setStatus'))) {
-        logger.info('🔍 Contenu duty détecté dans le message')
         await this.processDutyFromContent(message.content)
         return
       }
 
       // Si pas d'embeds initialement, attendre un peu et re-vérifier
-      if (message.embeds.length === 0) {
-        logger.info('⏳ Aucun embed détecté, attente de 2 secondes...')
-        
+      if (message.embeds.length === 0) {        
         setTimeout(async () => {
           try {
             // Re-fetch le message pour avoir les embeds à jour
             const channel = await this.client?.channels.fetch(this.logsChannelId!) as any
             if (channel && channel.messages) {
               const refreshedMessage = await channel.messages.fetch(message.id)
-              logger.info(`🔄 Message re-vérifié: content="${refreshedMessage.content}", embeds=${refreshedMessage.embeds.length}`)
               
               if (refreshedMessage.embeds.length > 0) {
                 await this.processMessageEmbeds(refreshedMessage)
               } else if (refreshedMessage.content && (refreshedMessage.content.includes('duty') || refreshedMessage.content.includes('setStatus'))) {
-                logger.info('🔍 Contenu duty détecté dans le message re-vérifié')
                 await this.processDutyFromContent(refreshedMessage.content)
               }
             }
@@ -1494,19 +1486,10 @@ class DiscordService {
    * Traite les embeds d'un message
    */
   private async processMessageEmbeds(message: Message): Promise<void> {
-    if (message.embeds.length > 0) {
-      message.embeds.forEach((embed, index) => {
-        logger.info(`📋 Embed ${index}: title="${embed.title}", fields=${embed.fields?.length || 0}`)
-      })
-    }
-
     // Traiter chaque embed
     for (const embed of message.embeds) {
       if (embed.title === 'duty - setStatus') {
-        logger.info('🔍 Événement duty détecté:', embed.title)
         await this.processDutyEvent(embed)
-      } else {
-        logger.info(`🔍 Embed ignoré: title="${embed.title}" (attendu: "duty - setStatus")`)
       }
     }
   }
@@ -1516,12 +1499,6 @@ class DiscordService {
    */
   private async processDutyFromContent(content: string): Promise<void> {
     try {
-      logger.info(`🔍 Analyse du contenu: "${content}"`)
-      
-      // Patterns possibles selon votre bot de service
-      // Ex: "duty - setStatus: true/false" ou similar
-      
-      // Exemple de parsing simple - à adapter selon le format réel
       if (content.includes('setStatus')) {
         // Essayer d'extraire les informations depuis le contenu
         // Format attendu pourrait être quelque chose comme:
@@ -1534,9 +1511,7 @@ class DiscordService {
         const status = statusMatch ? statusMatch[1].toLowerCase() : null
         const properName = userMatch ? userMatch[1].trim() : null
         const discordId = discordMatch ? discordMatch[1] : null
-        
-        logger.info(`📊 Parsing résultat: status=${status}, user=${properName}, discord=${discordId}`)
-        
+                
         if (status && discordId && properName) {
           if (status === 'true' || status === 'on' || status === 'start') {
             // Employé commence son service

--- a/apps/frontend/src/components/hooks/api-hooks.ts
+++ b/apps/frontend/src/components/hooks/api-hooks.ts
@@ -531,12 +531,14 @@ export const useEmployeeAvailability = () => {
     queryFn: async () => {
       try {
         const response = await apiRequest('/api/availability/check')
+        console.log('🔍 API Response:', response) // Debug log
         return {
           available: response.available !== false, // Utiliser la valeur de l'API
           count: response.count || 0,
           message: response.message
         } as EmployeeAvailability
       } catch (error: any) {
+        console.error('❌ API Error:', error) // Debug log
         // Si l'API retourne une erreur 503 (service indisponible)
         if (error.status === 503) {
           // Pour les erreurs 503, essayer de parser la réponse
@@ -564,8 +566,9 @@ export const useEmployeeAvailability = () => {
         } as EmployeeAvailability
       }
     },
-    refetchInterval: 30000, // Rafraîchir toutes les 30 secondes
-    staleTime: 25000, // Considérer les données comme obsolètes après 25 secondes
+    refetchInterval: 5000, // Rafraîchir toutes les 5 secondes (temporaire pour debug)
+    staleTime: 1000, // Considérer les données comme obsolètes après 1 seconde
+    refetchOnWindowFocus: true, // Rafraîchir quand la fenêtre reprend le focus
   })
 }
 


### PR DESCRIPTION
This pull request focuses on cleaning up debug logs in the backend and adjusting API polling behavior in the frontend for debugging purposes. The most important changes include removing redundant logging in the `DiscordService` class and modifying the polling configuration in the `useEmployeeAvailability` hook.

### Backend: Debug log cleanup in `DiscordService`

* Removed various `logger.info` statements that logged debug information, such as received messages, embed details, and parsing results, to streamline the code and reduce noise. (`apps/backend/app/services/discord_service.ts`: [[1]](diffhunk://#diff-835e23aa05d51b0ae85277b143ce72b5d6773335da3592e3b19620b79cdef617L1447-L1473) [[2]](diffhunk://#diff-835e23aa05d51b0ae85277b143ce72b5d6773335da3592e3b19620b79cdef617L1497-L1509) [[3]](diffhunk://#diff-835e23aa05d51b0ae85277b143ce72b5d6773335da3592e3b19620b79cdef617L1519-L1524) [[4]](diffhunk://#diff-835e23aa05d51b0ae85277b143ce72b5d6773335da3592e3b19620b79cdef617L1538-L1539)

### Frontend: API polling adjustments for debugging

* Added temporary debug logs (`console.log` and `console.error`) to track API responses and errors in the `useEmployeeAvailability` hook. (`apps/frontend/src/components/hooks/api-hooks.ts`: [apps/frontend/src/components/hooks/api-hooks.tsR534-R541](diffhunk://#diff-e7506dfb254bf0447574d646bee0c5099a66afdab643c4e8cf5641f50d6552b7R534-R541))
* Adjusted polling behavior to refresh every 5 seconds (down from 30 seconds) and marked data as stale after 1 second (down from 25 seconds). Enabled `refetchOnWindowFocus` to trigger updates when the window regains focus. These changes are temporary and intended for debugging. (`apps/frontend/src/components/hooks/api-hooks.ts`: [apps/frontend/src/components/hooks/api-hooks.tsL567-R571](diffhunk://#diff-e7506dfb254bf0447574d646bee0c5099a66afdab643c4e8cf5641f50d6552b7L567-R571))…ilability hook